### PR TITLE
Pull request for PHP error fixes, and some template improvements

### DIFF
--- a/h2o.php
+++ b/h2o.php
@@ -64,14 +64,15 @@ class H2o {
                 throw new Exception('Invalid template loader');
                 
             if (isset($options['searchpath'])){
-			    $this->searchpath = $options['searchpath'];
+                $this->searchpath = $options['searchpath'];
             } else if ($file) {
                 $this->searchpath = dirname(realpath($file)).DS;
             } else {
                 $this->searchpath = getcwd().DS;
             }
-                
-            $this->loader = new $loader($this->searchpath, $this->options);        
+
+            $loader_searchpath = is_array($this->searchpath) ? $this->searchpath : array($this->searchpath);
+            $this->loader = new $loader($loader_searchpath, $this->options);        
         }
         $this->loader->runtime = $this;
         

--- a/h2o/filters.php
+++ b/h2o/filters.php
@@ -15,6 +15,10 @@ class CoreFilters extends FilterCollection {
     static function join($value, $delimiter = ', ') {
         return join($delimiter, $value);
     }
+
+    static function length($value) {
+        return count($value);
+    }
     
     static function urlencode($data) {
         if (is_array($data)) {

--- a/h2o/filters.php
+++ b/h2o/filters.php
@@ -77,6 +77,12 @@ class StringFilters extends FilterCollection {
     static function escape($value, $attribute = false) {
         return htmlspecialchars($value, $attribute ? ENT_QUOTES : ENT_NOQUOTES);
     }
+
+    static function escapejson($value) {
+        // The standard django escapejs converts all non-ascii characters into hex codes.
+        // This function encodes the entire data structure, and strings get quotes around them.
+        return json_encode($value);
+    }
     
     static function force_escape($value, $attribute = false) {
         return self::escape($value, $attribute);

--- a/h2o/loaders.php
+++ b/h2o/loaders.php
@@ -118,7 +118,7 @@ class H2o_File_Loader extends H2o_Loader {
         $files = array_merge(array($object->filename), $object->templates);
         foreach ($files as $file) {
             if (!is_file($file))
-                $file = $this->get_template_path($this->searchpath,$filename);
+                $file = $this->get_template_path($this->searchpath, $file);
             
             if ($object->created < filemtime($file))
                 return true;

--- a/h2o/parser.php
+++ b/h2o/parser.php
@@ -2,7 +2,8 @@
 class H2o_Lexer {
     function __construct($options = array()) {
         $this->options = $options;
-        
+
+        $trim = '';
         if ($this->options['TRIM_TAGS'])
             $trim = '(?:\r?\n)?';
 

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -390,7 +390,6 @@ class Now_Tag extends H2o_Node {
     }
     
     function render($contxt, $stream) {
-        sleep(1);
         $time = date($this->format);
         $stream->write($time);
     }

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -387,6 +387,15 @@ class Debug_Tag extends H2o_Node {
     }
 }
 
+class Comment_Tag extends H2o_Node {
+    function __construct($argstring, $parser, $position) {
+        $parser->parse('endcomment');
+    }
+
+    function render($context, $stream, $index = 1) {
+    }
+}
+
 class Now_Tag extends H2o_Node {
     function __construct($argstring, $parser, $pos=0) {
         $this->format = $argstring;
@@ -436,5 +445,5 @@ class Csrf_token_Tag extends H2o_Node {
     }
 }
 
-H2o::addTag(array('block', 'extends', 'include', 'if', 'ifchanged', 'for', 'with', 'cycle', 'load', 'debug', 'now', 'autoescape', 'csrf_token'));
+H2o::addTag(array('block', 'extends', 'include', 'if', 'ifchanged', 'for', 'with', 'cycle', 'load', 'debug', 'comment', 'now', 'autoescape', 'csrf_token'));
 ?>

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -376,7 +376,7 @@ class Debug_Tag extends H2o_Node {
         } else {
             $object = $context->scopes[0];
         }
-        $output = "<pre>". print_r($object, true). "</pre>";
+        $output = "<pre>" . htmlspecialchars( print_r($object, true) ) . "</pre>";
         $stream->write($output);
     }
 }

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -130,6 +130,12 @@ class For_Tag extends H2o_Node {
     function render($context, $stream) {
         $iteratable = $context->resolve($this->iteratable);
 
+        // Make debugging a bit easier
+        if( ! is_array( $iteratable ) && ! $iteratable instanceof Traversable ) {
+            $repr = (is_object( $iteratable ) ? '<class: ' . get_class( $iteratable ) . '>' : (string)$iteratable );
+            throw new InvalidArgumentException("The for tag cannot iterate over the value: " . $repr);
+        }
+
         if ($this->reversed)
             $iteratable = array_reverse($iteratable);
 


### PR DESCRIPTION
Hi,

I've made some fixes and improvements when I was using H2o for my latest project.
I hope you like them, and include them in the official repository.

Errors fixed:
- type errors with using the 'searchpath as array'
- Fix PHP variable error  when TRIM_TAGS is false
- there was a sleep(1) in the 'now' tag.

Debugging improvements:
- the debug tag will escape the print_r() output
- The for loop gives an descriptive error when it can't iterate over a value.

Template improvement:
- Added length filter.
- Added 'comment' tag.

Best regards,
Diederik
