### PR TITLE
Do not ignore context if i18n is enabled

### DIFF
--- a/h2o/context.php
+++ b/h2o/context.php
@@ -125,7 +125,7 @@ class H2o_Context implements ArrayAccess {
                 $result = stripcslashes(substr($name, 1, -1));
             }
         }
-        if (!empty(self::$lookupTable)) {
+        if (!empty(self::$lookupTable) && $result == Null) {
             $result = $this->externalLookup($name);
         }
         $result = $this->applyFilters($result,$filters);


### PR DESCRIPTION
Do not attempt an external lookup should we already have resolved a context variable.

If i18n is enabled, an entry into 'lookupTables' is added.  Before 79befdd1 the context variable would have been directly returned, but afterward a resolved context variable would be re-looked-up in using the lookupTables (in this case, gettext), thus resulting in all context variables being set to Null.
