### PR TITLE
Raw tag

### DIFF
--- a/h2o/datatype.php
+++ b/h2o/datatype.php
@@ -65,11 +65,12 @@ class Evaluator {
  * $type of token, Block | Variable
  */
 class H2o_Token {
-    function __construct ($type, $content, $position) {
+    function __construct ($type, $content, $position, $raw) {
         $this->type = $type;
         $this->content = $content;
         $this->result='';
         $this->position = $position;
+        $this->raw = $raw;
     }
 
     function write($content){
@@ -98,10 +99,10 @@ class TokenStream  {
         return array_pop($this->stream);
     }
 
-    function feed($type, $contents, $position) {
+    function feed($type, $contents, $position, $raw) {
         if ($this->closed)
             throw new Exception('cannot feed closed stream');
-        $this->stream[] = new H2o_Token($type, $contents, $position);
+        $this->stream[] = new H2o_Token($type, $contents, $position, $raw);
     }
 
     function push($token) {

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -486,5 +486,14 @@ class Csrf_token_Tag extends H2o_Node {
     }
 }
 
-H2o::addTag(array('block', 'extends', 'include', 'if', 'ifchanged', 'for', 'with', 'cycle', 'load', 'debug', 'comment', 'now', 'autoescape', 'csrf_token'));
+class Raw_Tag extends H2o_Node {
+    function __construct($argstring, $parser, $pos=0){
+        $this->body = $parser->parse('endraw');
+    }
+    function render($context, $stream){
+        $stream->write($this->body);
+    }
+}
+
+H2o::addTag(array('block', 'extends', 'include', 'if', 'ifchanged', 'for', 'with', 'cycle', 'load', 'debug', 'comment', 'now', 'autoescape', 'csrf_token', 'raw'));
 ?>

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -487,11 +487,12 @@ class Csrf_token_Tag extends H2o_Node {
 }
 
 class Raw_Tag extends H2o_Node {
+    private $body;
     function __construct($argstring, $parser, $pos=0){
-        $this->body = $parser->parse('endraw');
+        $this->body = $parser->parseRaw('endraw');
     }
     function render($context, $stream){
-        $stream->write($this->body);
+        $this->body->render($context, $stream);
     }
 }
 


### PR DESCRIPTION
A tag which apparently has just been added to django 1.3.

I just came across the scenario where I needed to render jquery-tmpl templates (or similar) within a template of mine. As you may guess jquery-tmpl syntax messes with the tags and variables in h2o templates.

Hence the need for `{% raw %}` and corresponding `{% endraw %}` tags.

Anything within these two tags will not be parsed and passed on as though they were plain text all along.

Example:

```
Hello, {{ name }}
{% raw %}
<script type="text/x-tmpl">
{% for (cat in cats) { %}
    <span>{%=cat.name%}</span>
{% } %}
</script>
{% endraw %}
```

When rendered with `array('name' => "Bob")` produces as expected:

```
Hello, Bob
<script type="text/x-tmpl">
{% for (cat in cats) { %}
    <span>{%=cat.name%}</span>
{% } %}
</script>
```
