### PR TITLE
Fixes bug #48

### DIFF
--- a/example/i18n/index.php
+++ b/example/i18n/index.php
@@ -6,7 +6,7 @@ $template = new H2o('trans.html', array(
     'i18n' => array(
         'locale' => isset($_GET['lang']) ? $_GET['lang'] : false,
         'charset' => 'UTF-8',
-        'gettext_path' => '../bin/gettext/bin/',
+        'gettext_path' => (strtoupper(PHP_OS) == 'LINUX' ? '/usr/bin/' : '../bin/gettext/bin/'),
         'extract_message' => true,
         'compile_message' => true,
     )
@@ -16,7 +16,7 @@ $template = new H2o('trans.html', array(
 
 
 $time_start = microtime(true);
-
+     
 echo $template->render(array(
     'users' => array(
         array(
@@ -38,6 +38,11 @@ echo $template->render(array(
             'username' =>           'foobar',
             'tasks' => array(),
             'user_id' =>            4
+        ),
+        array(
+            'username' =>           'test',
+            'tasks' => null,
+            'user_id' =>            5
         )
     )
 ));

--- a/ext/i18n.php
+++ b/ext/i18n.php
@@ -384,9 +384,9 @@ function templize($source) {
             }
             elseif ($t->type == 'text') {
                 if ($is_plural)
-                    $plurals[] = addslashes($t->content);
+                    $plurals[] = escapesinglequote($t->content);
                 else
-                    $singulars[] = addslashes($t->content);
+                    $singulars[] = escapesinglequote($t->content);
             }
             elseif ($t->type == 'variable') {
                 @list($var, $filters ) = explode('|', $t->content);
@@ -417,5 +417,17 @@ function templize($source) {
     if ($result)
     return "\n".$result . ";\n";
 }
+
+/**
+ * handles only single quote escaping, taking care of double escaping.
+ *
+ * @param $str string value to be escaped
+ *
+ * @return string escaped string value
+ */
+function escapesinglequote($str) {
+    return str_replace('\'', '\\\'', str_replace('\\\'', '\'', $str));
+}
+
 
 ?>

--- a/ext/i18n.php
+++ b/ext/i18n.php
@@ -326,7 +326,8 @@ class H2o_I18n {
             if ($f->isDot()) continue;
 
             if ($f->isFile()) {
-                $ext = end(explode(".", $f->getFilename()));
+                $tmp = explode(".", $f->getFilename());
+                $ext = end($tmp);
                 if ($ext && in_array($ext, $exts) ) {
                     $results[] = $f->getPathname();
                 }

--- a/ext/i18n.php
+++ b/ext/i18n.php
@@ -246,7 +246,7 @@ class H2o_I18n {
             # merge messages for each language
             if (is_file($pot_file)) {
                 $return = $error = '';
-                $cmd = $this->gettext_path."msguniq --to-code=utf-8 \"{$pot_file}\"";
+                $cmd = $this->gettext_path."msguniq --no-wrap --no-location --to-code=utf-8 \"{$pot_file}\"";
 
                 if (!exec($cmd, $return))
                     throw new Exception('Msgunique failed');

--- a/ext/i18n.php
+++ b/ext/i18n.php
@@ -153,7 +153,7 @@ class H2o_I18n {
             throw new Exception('locale directory not found and failed to created '.$this->searchpath);
     }
 
-    function gettext($name, $context) {
+    static function gettext($name, $context) {
         $gettext = self::$gettext;
         if (!is_string($name)) return ;
         $syntax = '/_\(((?:".*?")|(?:\'.*?\'))\)/';

--- a/h2o.php
+++ b/h2o.php
@@ -14,20 +14,20 @@ require H2O_ROOT.'h2o/context.php';
 /**
  * Example:
  *  $h2o = new H2O('./template.html', array("loader"=>'file'));
- *  
- *  
+ *
+ *
  *  $h2o = new H2O('template.html', array("loader"=>'hash'));
  */
 class H2o {
     var $searchpath;
     var $context;
     var $loader = false;
-    
+
     static $tags = array();
     static $filters = array();
     static $extensions = array();
-    
-    function getOptions($options = array()) {
+
+    static function getOptions($options = array()) {
         return array_merge(array(
             'loader'            =>       'file',
             'cache'             =>      'file',     // file | apc | memcache
@@ -35,7 +35,7 @@ class H2o {
             'cache_ttl'         =>      3600,     // file | apc | memcache
             'searchpath'        =>      false,
             'autoescape'        =>      true,
-        
+
             // Enviroment setting
             'BLOCK_START'       =>      '{%',
             'BLOCK_END'         =>      '%}',
@@ -46,10 +46,10 @@ class H2o {
             'TRIM_TAGS'         =>      true
         ), $options);
     }
-    
+
     function __construct($file = null, $options = array()) {
         # Init a environment
-        $this->options = $this->getOptions($options);        
+        $this->options = $this->getOptions($options);
         $loader = $this->options['loader'];
 
         if (!$loader)
@@ -62,7 +62,7 @@ class H2o {
             $loader = "H2o_{$loader}_Loader";
             if (!class_exists($loader, false))
                 throw new Exception('Invalid template loader');
-                
+
             if (isset($options['searchpath'])){
                 $this->searchpath = $options['searchpath'];
             } else if ($file) {
@@ -72,15 +72,15 @@ class H2o {
             }
 
             $loader_searchpath = is_array($this->searchpath) ? $this->searchpath : array($this->searchpath);
-            $this->loader = new $loader($loader_searchpath, $this->options);        
+            $this->loader = new $loader($loader_searchpath, $this->options);
         }
         $this->loader->runtime = $this;
-        
+
         if (isset($options['i18n'])) {
             h2o::load('i18n');
             $this->i18n = new H2o_I18n($this->searchpath, $options['i18n']);
         }
-    
+
         if ($file) {
             $this->nodelist = $this->loadTemplate($file);
         }
@@ -89,11 +89,11 @@ class H2o {
     function loadTemplate($file) {
         return $this->nodelist = $this->loader->read_cache($file);
     }
-    
+
     function loadSubTemplate($file) {
         return $this->loader->read($file);
     }
-    
+
     # Build a finalized nodelist from template ready to be cached
     function parse($source, $filename = '', $env = null) {
         if (!$env)
@@ -117,17 +117,17 @@ class H2o {
         if (!$this->context) {
             $this->context = new H2o_Context($this->defaultContext(), $this->options);
         }
-        
+
         # Extend or set value
         if (is_array($context)) {
             return $this->context->extend($context);
-        } 
+        }
         elseif (is_string($context)) {
             return $this->context[$context] = $value;
         }
         return false;
     }
-    
+
     # Render the nodelist
     function render($context = array()) {
         $this->set($context);
@@ -155,32 +155,32 @@ class H2o {
     /**
      * Register a new tag
      *
-     * 
+     *
      * h2o::addTag('tag_name', 'ClassName');
-     * 
+     *
      * h2o::addTag(array(
      *      'tag_name' => 'MagClass',
      *      'tag_name2' => 'TagClass2'
      * ));
      *
      *  h2o::addTag('tag_name');      // Tag_name_Tag
-     * 
-     * h2o::addTag(array('tag_name', 
+     *
+     * h2o::addTag(array('tag_name',
      * @param unknown_type $tag
      * @param unknown_type $class
      */
     static function addTag($tag, $class = null) {
         $tags = array();
         if (is_string($tag)) {
-            if (is_null($class)) 
+            if (is_null($class))
                 $class = ucwords("{$tag}_Tag");
             $tags[$tag] = $class;
         } elseif (is_array($tag)) {
             $tags = $tag;
         }
-        
+
         foreach ($tags as $tag => $tagClass) {
-            if (is_integer($tag)) {        
+            if (is_integer($tag)) {
                 unset($tags[$tag]);
                 $tag = $tagClass;
                 $tagClass = ucwords("{$tagClass}_Tag");
@@ -218,19 +218,19 @@ class H2o {
         }
         if (is_null($callback))
             $callback = $filter;
-            
+
         if (!is_callable($callback)) {
             return false;
         }
         self::$filters[$filter] = $callback;
     }
-    
+
     static function addLookup($callback) {
         if (is_callable($callback)) {
             H2o_Context::$lookupTable[] = $callback;
         } else die('damm it');
     }
-    
+
     static function load($extension, $file = null) {
         if (!$file) {
             $file = H2O_ROOT.'ext'.DS.$extension.'.php';
@@ -254,9 +254,9 @@ class H2o {
  */
 function h2o($name, $options = array()) {
     $is_file = '/([^\s]*?)(\.[^.\s]*$)/';
-    
+
     if (!preg_match($is_file, $name)) {
-        return H2o::parseString($name, $options); 
+        return H2o::parseString($name, $options);
     }
 
     $instance = new H2o($name, $options);


### PR DESCRIPTION
Changes:
- Removed debugging Exception that is thrown if template variables
  loops over an empty array or null (see example/i18n/index.php for
  testing).
- Cleaned up trailing spaces (and CRLF) of committing files.
- Added smart to make i18n example work out of the box on Linux
  machines as well.

(sorry for the trailing diff, speedmax, looks like Git diff considers 2 different files, but the only change made in the tags.php file was the removal of lines:

``` diff
134      -        // Make debugging a bit easier
135      -        if( ! is_array( $iteratable ) && ! $iteratable instanceof Traversable ) {
136      -            $repr = (is_object( $iteratable ) ? '<class: ' . get_class( $iteratable ) . '>' : (string)$iteratable );
137      -            throw new InvalidArgumentException("The for tag cannot iterate over the value: " . $repr);
138      -        }
```

Hope that clarifies the need for this merge.

Thanks,
