### PR TITLE
BugFix: Add directory separator to end of searchpath elements.

### DIFF
--- a/h2o/loaders.php
+++ b/h2o/loaders.php
@@ -54,10 +54,10 @@ class H2o_File_Loader extends H2o_Loader {
 
 	function get_template_path($search_path, $filename){
 
-        
-        for ($i=0 ; $i < count($search_path) ; $i++) 
-        { 
-            
+
+        for ($i=0 ; $i < count($search_path) ; $i++)
+        {
+            $search_path[$i] = $search_path[$i].DS;
             if(file_exists($search_path[$i] . $filename)) {
                 $filename = $search_path[$i] . $filename;
                 return $filename;


### PR DESCRIPTION
Fix failing unittests (could not find template exceptions):

```
$h2o = h2o('emails/base.html', array(
            'searchpath' => dirname(__FILE__).DS.'templates'
        ));
```

Did not find the template because it searched for `templatesemails/base.html` instead of for
`templates/emails/base.html`
