### PR TITLE
Feat: Implement iterating over explicit list.

### DIFF
--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -100,8 +100,8 @@ class For_Tag extends H2o_Node {
     private $syntax = '{
         ([a-zA-Z][a-zA-Z0-9-_]*)(?:,\s?([a-zA-Z][a-zA-Z0-9-_]*))?
         \s+in\s+
-        ([a-zA-Z][a-zA-Z0-9-_]*(?:\.[a-zA-Z_0-9][a-zA-Z0-9_-]*)*)\s*   # Iteratable name
-        (?:limit\s*:\s*(\d+))?\s*
+        ([a-zA-Z0-9][a-zA-Z0-9-_,]*(?:\.[a-zA-Z_0-9][a-zA-Z0-9_-]*)*)\s*   # Iteratable name
+        (?:limit\s*:\s*-?(\d+))?\s*
         (reversed)?                                                     # Reverse keyword
     }x';
 
@@ -124,12 +124,16 @@ class For_Tag extends H2o_Node {
         if (!$this->item) {
             list($this->key, $this->item) = array($this->item, $this->key);
         }
-        $this->iteratable = symbol($this->iteratable);
+        if ( strpos($this->iteratable,',') > 0 ) {
+            $this->iteratable = explode(',',$this->iteratable);
+        } else $this->iteratable = symbol($this->iteratable);
         $this->reversed = (bool) $this->reversed;
     }
 
     function render($context, $stream) {
-        $iteratable = $context->resolve($this->iteratable);
+        if ( ! is_array($this->iteratable) ) {
+            $iteratable = $context->resolve($this->iteratable);
+        } else $iteratable = $this->iteratable;
 
         if ($this->reversed)
             $iteratable = array_reverse($iteratable);

--- a/spec/tags_spec.php
+++ b/spec/tags_spec.php
@@ -18,6 +18,17 @@ class Describe_for_tag extends SimpleSpec {
         expects($result)->should_be('12345');    
     }
     
+
+    function should_iterate_over_a_list_of_objects() {
+       $result = h2o('{% for e in 1,2,3,4,5 %}{{ e }}{% endfor %}')->render();
+       expects($result)->should_be('12345');
+    }
+
+    function should_reverse_list_when_reversed_keyword_supplied() {
+       $result = h2o('{% for e in 1,2,3,4,5 reversed %}{{ e }}{% endfor %}')->render();
+       expects($result)->should_be('54321');
+    }
+
     function should_reverse_array_when_reversed_keyword_supplied() {
         $result = h2o('{% for e in items reversed %}{{ e }}{% endfor %}')->render(array(
             'items'=> array(1,2,3,4,5)


### PR DESCRIPTION
When using h2o I found it useful to be able to use the {% for %} block to iterate over a list
given explicitly in the template, e.g.:

```
{% for year in 2014, 2015, 2016, 2017 %}
    See <a href={{year}}.html>here</a>
{% endfor %}
```

This commit implements this feature by allowing the for to iterate over a comma-separated list of values.
