### PR TITLE
Feature: Implement complex expressions

### DIFF
--- a/h2o/parser.php
+++ b/h2o/parser.php
@@ -153,6 +153,9 @@ class H2o_Parser {
             elseif( $token == 'operator') {
                 $current_buffer[] = array('operator'=>$data);
             }
+            elseif( $token == 'parentheses' ) {
+                $current_buffer[] = array('parentheses'=>$data);
+            }
         }
         return $result;
     }
@@ -170,7 +173,7 @@ class H2O_RE {
         self::$boolean    = '/true|false/';
         self::$seperator    = '/,/';
         self::$pipe         = '/\|/';
-        self::$operator     = '/\s?(>|<|>=|<=|!=|==|!|and |not |or )\s?/i';
+        self::$operator     = '/\s?(>|<|>=|<=|!=|==|!|\+|-|\*|\/|and |not |or |mod )\s?/i';
         self::$number       = '/\d+(\.\d*)?/';
         self::$name         = '/[a-zA-Z][a-zA-Z0-9-_]*(?:\.[a-zA-Z_0-9][a-zA-Z0-9_-]*)*/';
 
@@ -194,7 +197,8 @@ class ArgumentLexer {
     private $match;
     private $pos = 0, $fpos, $eos;
     private $operator_map = array(
-        '!' => 'not', '!='=> 'ne', '==' => 'eq', '>' => 'gt', '<' => 'lt', '<=' => 'le', '>=' => 'ge'
+        '!' => 'not', '!='=> 'ne', '==' => 'eq', '>' => 'gt', '<' => 'lt', '<=' => 'le', '>=' => 'ge',
+        '*' => 'mul', '/' => 'div', '+' => 'plus', '-' => 'minus', 'or' => 'or_', 'and'=>'and_',
     );
 
     function __construct($source, $fpos = 0){
@@ -214,6 +218,9 @@ class ArgumentLexer {
                     if(isset($this->operator_map[$operator]))
                         $operator = $this->operator_map[$operator];
                     $result[] = array('operator', $operator);
+                }
+                elseif ($this->scan(H2O_RE::$parentheses)) {
+                    $result[] = array('parentheses',$this->match);
                 }
                 elseif ($this->scan(H2O_RE::$boolean))
                     $result[] = array('boolean', $this->match);

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -72,6 +72,10 @@ class If_Tag extends H2o_Node {
 
         $this->args = H2o_Parser::parseArguments($argstring);
 
+        // Remove the 'expression_end' token at the end
+        array_pop($this->args);
+
+
         $first = current($this->args);
         if (isset($first['operator']) && $first['operator'] === 'not') {
             array_shift($this->args);

--- a/h2o/tags.php
+++ b/h2o/tags.php
@@ -64,8 +64,6 @@ class If_Tag extends H2o_Node {
     private $negate;
 
     function __construct($argstring, $parser, $position = 0) {
-        if (preg_match('/\s(and|or)\s/', $argstring))
-            throw new TemplateSyntaxError('H2o doesn\'t support multiple expressions');
 
         $this->body = $parser->parse('endif', 'else');
 

--- a/spec/nodes_spec.php
+++ b/spec/nodes_spec.php
@@ -31,5 +31,27 @@ class Describe_variable_node extends SimpleSpec {
         $result = h2o('{{ name|capitalize }}')->render(compact('name'));
         expects($result)->should_be('Taylor Luk');
     }
+
+    function should_correctly_parse_expressions() {
+        $pi = 3;
+        $result = h2o('{{ (pi+1)/2+10 }}')->render(compact('pi'));
+        expects($result)->should_be('12');
+
+        $except = false;
+        try {
+            $res = h2o('{{ ()pi+1)/2+10 }}')->render(compact('pi'));
+        } catch (Exception $e) {
+            $except = true;
+        }
+        expects($except)->should_be(true);
+
+        $except = false;
+        try {
+            $res = h2o('{{ +1 }}')->render(compact('pi'));
+        } catch (Exception $e) {
+            $except = true;
+        }
+        expects($except)->should_be(true);
+    }
 }
 ?>

--- a/spec/parser_spec.php
+++ b/spec/parser_spec.php
@@ -58,20 +58,21 @@ class Describe_Argument_Lexer extends SimpleSpec {
     function should_parse_named_arguments() {
         $result = $this->parse("something | filter 11, name: 'something', age: 18, var: variable, active: true");
         $expected = array(
-            array(
-                ':something', 'filters' => array( 
-	                array(':filter', 11, array('name' => "'something'", 'age' => 18, 'var' => ':variable', 'active'=>'true'))
+                ':something',
+                array( 'expression_end',
+                       'filters' => array(
+	                  array(':filter', 11, array('name' => "'something'", 'age' => 18, 'var' => ':variable', 'active'=>'true'))
+                        )
                 )
-            )
         );
         expects($result)->should_be($expected);
     }
     
     function should_parse_variable_contains_operators() {
-        expects($this->parse("org"))->should_be(array(':org'));
-        expects($this->parse("dand"))->should_be(array(':dand'));
-        expects($this->parse("xor"))->should_be(array(':xor'));
-        expects($this->parse("notd"))->should_be(array(':notd'));
+        expects($this->parse("org"))->should_be(array(':org','expression_end'));
+        expects($this->parse("dand"))->should_be(array(':dand','expression_end'));
+        expects($this->parse("xor"))->should_be(array(':xor','expression_end'));
+        expects($this->parse("notd"))->should_be(array(':notd','expression_end'));
     }
     
     private function parse($string) {

--- a/spec/tags_spec.php
+++ b/spec/tags_spec.php
@@ -7,6 +7,11 @@ class Describe_if_tag extends SimpleSpec {
         $results = h2o('{% if 4 > 3 %}yes{% endif %}')->render();
         expects($results)->should_be('yes');
     }
+
+    function should_evaluate_complex_boolean_expression() {
+        $results = h2o('{% if  (4+7) > 5 and 7 == (2+1)*2+1 %}yes{% endif %}')->render();
+        expects($results)->should_be('yes');
+    }
 }
 
 


### PR DESCRIPTION
I found it annoying that the `{% if %}` tag only allowed simple expressions (no `and`, `or`, ...)
which forced me to nest if blocks. Similarly I found it convenient to be able to write

```
{{ year-1 }}
```

instead of populating the scope with a new variable `$prev_year`.  These two commits are trying to implement the two features. 

The first commit implements a simple stack-based expression parser/evaluator which allows compound expressions in the `{% if %}` tag. The second commit, which I am less sure of, implements expression evaluation for variable blocks. 

I am not quite sure the second commit doesn't break something (although all unit tests pass and I didn't notice any breakage) because it changes the way the `parseArguments` method works. That method is not used in many places, thought. 

The way it works now is as follows:

When parsing a variable block in `parseArguments` the code iterates over the list of tokens until it reach a `filter_start` token or the end. At that point it adds an `expression_end` token to the result and continue exactly as in the original code. So the difference in `parseArguments` is only that a new `expression_end` token is added to the returned array.

The rest of the work is done in the `render` method of the `VariableNode` where we first call `Evaluator::eval_expression` (the expression parser/evaluator) to evaluate the expression and then
we apply any potential filters.
