### PR TITLE
Needed to require parser when loading files from cache 

### DIFF
--- a/h2o.php
+++ b/h2o.php
@@ -10,6 +10,7 @@ require H2O_ROOT.'h2o/tags.php';
 require H2O_ROOT.'h2o/errors.php';
 require H2O_ROOT.'h2o/filters.php';
 require H2O_ROOT.'h2o/context.php';
+require H2O_ROOT.'h2o/parser.php';
 
 /**
  * Example:


### PR DESCRIPTION
This could be a byproduct of using autoloading on PHP 5.5
